### PR TITLE
QMQ-000014: Adapt frontend for api consumption

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -15,14 +15,14 @@ export function useAuth() {
         resolver: zodResolver(loginSchema),
     });
 
-    const onSubmit = async (data: LoginFormData) => {
+    const onSubmit = async (_data: LoginFormData) => {
         setIsLoading(true);
         try {
-            const result = await authApi.login(data);
+            /* const result = await authApi.login(data);
 
             if (result.result.idTipoMensaje !== 2) {
                 return { success: false };
-            }
+            } */
 
             return { success: true };
         } catch (error) {

--- a/src/hooks/useRagStream.ts
+++ b/src/hooks/useRagStream.ts
@@ -1,0 +1,153 @@
+// useRagStream.ts
+import { useRef, useState, useCallback } from "react";
+
+type JsonRecord = Record<string, unknown>;
+
+export type ChatStreamingPayload = {
+  user_id: string;
+  message: string;
+  company_id?: string;
+  collection?: string | null;
+  top_k?: number;
+  similarity_threshold?: number;
+  temperature?: number;
+  max_tokens?: number;
+};
+
+export type MetadataEvent = { type: "metadata" } & JsonRecord;
+export type ChunkEvent = { type: "chunk"; content: string };
+export type CompleteEvent = { type: "complete" } & JsonRecord;
+export type UnknownEvent = { type: string } & JsonRecord;
+
+export type StreamEvent = MetadataEvent | ChunkEvent | CompleteEvent | UnknownEvent;
+
+function isRecord(v: unknown): v is JsonRecord {
+  return typeof v === "object" && v !== null;
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === "string";
+}
+
+function safeJsonParse(input: string): unknown {
+  try {
+    return JSON.parse(input);
+  } catch {
+    return undefined;
+  }
+}
+
+function asStreamEvent(u: unknown): StreamEvent | undefined {
+  if (!isRecord(u)) return undefined;
+  const t = u["type"];
+  if (!isString(t)) return undefined;
+
+  if (t === "chunk") {
+    if (isString(u["content"])) {
+      return { type: "chunk", content: u["content"] };
+    }
+    return undefined;
+  }
+
+  // metadata / complete u otros: los aceptamos como JsonRecord
+  return { ...(u as JsonRecord), type: t } as StreamEvent;
+}
+
+export function useRagStream(url: string) {
+  const [answer, setAnswer] = useState<string>("");
+  const [metadata, setMetadata] = useState<MetadataEvent | null>(null);
+  const [isStreaming, setIsStreaming] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const start = useCallback(
+    async (payload: ChatStreamingPayload) => {
+      setAnswer("");
+      setMetadata(null);
+      setIsStreaming(true);
+      setError(null);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const res = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          signal: controller.signal,
+        });
+
+        if (!res.ok || !res.body) {
+          const text = await res.text().catch(() => "");
+          throw new Error(`HTTP ${res.status}: ${text}`);
+        }
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder("utf-8");
+
+        let buffer = "";
+
+        const flushChunk = (block: string) => {
+          // Cada bloque puede tener varias líneas; nos quedamos con las que empiezan con "data:"
+          for (const line of block.split("\n")) {
+            if (!line.startsWith("data:")) continue;
+            const jsonStr = line.slice(5).trim(); // quita "data:"
+            if (!jsonStr) continue;
+
+            const parsed = safeJsonParse(jsonStr);
+            const evt = asStreamEvent(parsed);
+            if (!evt) continue;
+
+            switch (evt.type) {
+              case "metadata":
+                setMetadata(evt as MetadataEvent);
+                break;
+              case "chunk":
+                setAnswer((evt as ChunkEvent).content);
+                break;
+              case "complete":
+                break;
+              default:
+                break;
+            }
+          }
+        };
+
+        // Lectura por streaming
+         
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          // Los eventos SSE se separan por "\n\n"
+          const parts = buffer.split("\n\n");
+          buffer = parts.pop() ?? "";
+          for (const part of parts) flushChunk(part);
+        }
+
+        // Si quedó algo en buffer (sin \n\n final), intenta parsearlo
+        if (buffer.trim()) flushChunk(buffer);
+      } catch (err: unknown) {
+        // AbortError: no lo tratamos como error de UI
+        if (err instanceof DOMException && err.name === "AbortError") {
+          // cancelado por el usuario
+        } else if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError("Stream error");
+        }
+      } finally {
+        setIsStreaming(false);
+      }
+    },
+    [url]
+  );
+
+  return { start, cancel, isStreaming, answer, metadata, error };
+}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -9,17 +9,25 @@ export const HomePage = () => {
         setCargando(true);
         setRespuesta('');
         try {
-            const res = await fetch('https://backpilotoia-f7eeapfvazc3axcu.canadacentral-01.azurewebsites.net/api/chat', {
+            const res = await fetch('http://127.0.0.1:8000/api/v1/chat', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ mensaje: consulta }),
+                body: JSON.stringify({
+                  message: consulta,
+                  user_id: "user123",
+                  company_id: "Edificaciones",
+                  similarity_threshold: 0.7,
+                  temperature: 0.3,
+                  max_tokens: 512
+                }),
             });
-
+            console.log(res)
             const data = await res.json();
-            setRespuesta(data.respuesta);
+            setRespuesta(data.answer);
         } catch (error) {
+            console.log(error)
             setRespuesta('Error al consultar la API');
         } finally {
             setCargando(false);

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -20,7 +20,7 @@ export const HomePage = () => {
                   company_id: "Edificaciones",
                   similarity_threshold: 0.7,
                   temperature: 0.3,
-                  max_tokens: 512
+                  max_tokens: 1024
                 }),
             });
             console.log(res)

--- a/src/pages/home/HomeStreaming.tsx
+++ b/src/pages/home/HomeStreaming.tsx
@@ -29,7 +29,7 @@ const HomeStreaming = () => {
           company_id: 'Edificaciones',
           similarity_threshold: 0.7,
           temperature: 0.3,
-          max_tokens: 512,
+          max_tokens: 1024,
         }),
         signal: controller.signal,
       });

--- a/src/pages/home/HomeStreaming.tsx
+++ b/src/pages/home/HomeStreaming.tsx
@@ -26,10 +26,10 @@ const HomeStreaming = () => {
         body: JSON.stringify({
           message: consulta,
           user_id: 'user123',
-          company_id: 'Edificaciones',
-          similarity_threshold: 0.7,
+          company_id: 'CrisTest4',
+          similarity_threshold: 0.9,
           temperature: 0.3,
-          max_tokens: 512,
+          max_tokens: 1024,
         }),
         signal: controller.signal,
       });

--- a/src/pages/home/HomeStreaming.tsx
+++ b/src/pages/home/HomeStreaming.tsx
@@ -5,6 +5,7 @@ const HomeStreaming = () => {
   const [respuesta, setRespuesta] = useState('');
   const [cargando, setCargando] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  const respuestaRef = useRef<HTMLTextAreaElement>(null);
 
   const manejarConsulta = async () => {
     setCargando(true);
@@ -16,7 +17,12 @@ const HomeStreaming = () => {
     try {
       const res = await fetch('http://127.0.0.1:8000/api/v1/chat-streaming', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json' ,
+          'Accept': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive'
+        },
         body: JSON.stringify({
           message: consulta,
           user_id: 'user123',
@@ -51,6 +57,13 @@ const HomeStreaming = () => {
             if (evt.type === 'chunk' && typeof evt.content === 'string') {
               // El servidor ya concatena el contenido, así que solo reflejamos
               setRespuesta(evt.content);
+              queueMicrotask(() => {
+                if (respuestaRef.current) {
+                  respuestaRef.current.scrollTop = respuestaRef.current.scrollHeight;
+                }
+              })
+            } else if (evt.type === 'complete') {
+              controller.abort();
             }
             // Si quieres usar metadata/complete, puedes manejarlo aquí
           } catch {
@@ -134,6 +147,7 @@ const HomeStreaming = () => {
         </div>
 
         <textarea
+          ref={respuestaRef}
           value={respuesta}
           readOnly
           className='respuesta'

--- a/src/pages/home/HomeStreaming.tsx
+++ b/src/pages/home/HomeStreaming.tsx
@@ -1,0 +1,169 @@
+import { useState, useRef } from 'react';
+
+const HomeStreaming = () => {
+  const [consulta, setConsulta] = useState('');
+  const [respuesta, setRespuesta] = useState('');
+  const [cargando, setCargando] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const manejarConsulta = async () => {
+    setCargando(true);
+    setRespuesta('');
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const res = await fetch('http://127.0.0.1:8000/api/v1/chat-streaming', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: consulta,
+          user_id: 'user123',
+          company_id: 'Edificaciones',
+          similarity_threshold: 0.7,
+          temperature: 0.3,
+          max_tokens: 512,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok || !res.body) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`HTTP ${res.status}: ${text}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder('utf-8');
+      let buffer = '';
+
+      const flushBlock = (block: string) => {
+        // Cada bloque puede tener varias líneas: buscamos las que empiezan con "data:"
+        const lines = block.split('\n');
+        for (const line of lines) {
+          if (!line.startsWith('data:')) continue;
+          const jsonStr = line.slice(5).trim(); // quita "data:"
+          if (!jsonStr) continue;
+
+          try {
+            const evt = JSON.parse(jsonStr);
+            // Tu backend envía: metadata | chunk | complete
+            if (evt.type === 'chunk' && typeof evt.content === 'string') {
+              // El servidor ya concatena el contenido, así que solo reflejamos
+              setRespuesta(evt.content);
+            }
+            // Si quieres usar metadata/complete, puedes manejarlo aquí
+          } catch {
+            // ignoramos frames inválidos
+          }
+        }
+      };
+
+      // Leer el stream por partes
+       
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        // Los eventos SSE vienen separados por "\n\n"
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() || '';
+        for (const part of parts) flushBlock(part);
+      }
+
+      // Si quedó algo sin el separador final, intenta procesarlo
+      if (buffer.trim()) flushBlock(buffer);
+    } catch (err) {
+      if (err instanceof DOMException && err?.name !== 'AbortError') {
+        console.error(err);
+        setRespuesta('Error al consultar la API');
+      }
+    } finally {
+      setCargando(false);
+    }
+  };
+
+  const cancelar = () => {
+    abortRef.current?.abort();
+  };
+
+  return (
+    <div className='contenido'>
+      <img
+        src="https://staffing.fractal.com.pe/img/fractal-logo.png"
+        className='fractal'
+        alt="Logo Fractal"
+      />
+
+      <section className='izquierda'>
+        <div className="titulo-info">
+          <h1 className='Titulo'>Piloto IA</h1>
+
+          <div className="info-container info-mediana">
+            <label className="info-label">
+              <b>Reglamento de la Ley N° 32069, ley general de contrataciones públicas</b><br />
+            </label>
+            <a
+              href="https://acortar.link/Rtr3wE"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="info-link"
+            >
+              https://acortar.link/Rtr3wE
+            </a>
+          </div>
+        </div>
+
+        <div className='formulario'>
+          <textarea
+            value={consulta}
+            onChange={(e) => setConsulta(e.target.value)}
+            placeholder="Escribe tu consulta"
+            className='pregunta'
+            disabled={cargando}
+          />
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button onClick={manejarConsulta} className='Boton' disabled={cargando}>
+              {cargando ? <div className="spinner"></div> : 'Enviar'}
+            </button>
+            <button onClick={cancelar} className='Boton' disabled={!cargando}>
+              Cancelar
+            </button>
+          </div>
+        </div>
+
+        <textarea
+          value={respuesta}
+          readOnly
+          className='respuesta'
+        />
+      </section>
+
+      <section>
+        <img
+          src='https://cdn.agenciasinc.es/var/ezwebin_site/storage/images/_aliases/img_1col/reportajes/las-mentiras-visuales-de-la-ia/11896126-1-esl-MX/Las-mentiras-visuales-de-la-IA.jpg'
+          className='imagen'
+          alt="Imagen IA"
+        />
+
+        <div className="info-container info-grande">
+          <label className="info-label">
+            <b>Reglamento de la Ley N° 32069, ley general de contrataciones públicas</b><br />
+          </label>
+          <a
+            href="https://acortar.link/Rtr3wE"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="info-link"
+          >
+            https://acortar.link/Rtr3wE
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+
+export default HomeStreaming;

--- a/src/routes/GuardRoute.tsx
+++ b/src/routes/GuardRoute.tsx
@@ -10,7 +10,8 @@ export const GuardRoute = ({ children }: { children: ReactNode }) => {
 
     useEffect(() => {
         const checkAuth = async () => {
-            const isValid = await authApi.validateToken();
+            //const isValid = await authApi.validateToken();
+            const isValid = true;
             if (!isValid) {
                 toast("Sesión caducada, vuelve a iniciar sesión", { type: "warning" });
                 navigate("/login");

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -3,6 +3,7 @@ import { HomePage } from "../pages/home/Home";
 import { LoginPage } from "../pages/login/Login";
 import { App } from "../App";
 import { GuardRoute } from "./GuardRoute";
+import HomeStreaming from "../pages/home/HomeStreaming";
 
 export const router = createHashRouter([
   {
@@ -21,7 +22,8 @@ export const router = createHashRouter([
         path: "home",
         element: (
           <GuardRoute>
-            <HomePage />
+            {/* <HomePage /> */}
+            <HomeStreaming />
           </GuardRoute>
         ),
       },


### PR DESCRIPTION
This pull request introduces streaming support for chat responses, refactors API integration for improved structure, and adds a new streaming-enabled home page. The most significant changes include implementing a `useRagStream` hook for handling server-sent event (SSE) chat streams, creating a new `HomeStreaming` page component, updating the router to use this streaming page, and modifying API request payloads and endpoints for consistency with the backend.

**Streaming and API Integration:**
- Added the `useRagStream` custom hook to handle chat streaming via SSE, including event parsing, cancellation, and state management. (`src/hooks/useRagStream.ts`)
- Created a new `HomeStreaming` page that consumes the streaming API, manages stream state and cancellation, and updates the UI in real time as chunks arrive. (`src/pages/home/HomeStreaming.tsx`)
- Updated the router to use `HomeStreaming` instead of the old `HomePage` for the `/home` route, enabling streaming by default. (`src/routes/Router.tsx`) [[1]](diffhunk://#diff-1d002f67fd2a3f938d2ba85985e592fae785450e1c049663982149919e0f6b07R6) [[2]](diffhunk://#diff-1d002f67fd2a3f938d2ba85985e592fae785450e1c049663982149919e0f6b07L24-R26)

**API Request and Authentication Adjustments:**
- Changed the API endpoint and payload structure in `HomePage` to match backend expectations (e.g., renaming `mensaje` to `message`, adding `user_id`, `company_id`, and other parameters). (`src/pages/home/Home.tsx`)
- Temporarily bypassed authentication token validation in guarded routes for development/testing purposes. (`src/routes/GuardRoute.tsx`)

**Other Minor Changes:**
- Commented out the login logic in the `useAuth` hook, likely for development or testing. (`src/hooks/useAuth.ts`)

These changes together enable real-time, streaming chat responses in the application and set up the codebase for further development and testing of streaming features.